### PR TITLE
Use a login shell for scriptlets to pick up reasonable PATH

### DIFF
--- a/launcher/main.c
+++ b/launcher/main.c
@@ -74,11 +74,11 @@ char* getScriptCommand(char* scriptPath)
     }
     escapedPath[escapedPathLength] = '\0';
 
-    char* command = buildCommand("sh \"%s\"", escapedPath);
+    char* command = buildCommand("sh -l \"%s\"", escapedPath);
 
     if (header.useHooks) { // useHooks script - source it and use `on_run`
         free(command);
-        command = buildCommand("sh -c \"source \\\"%s\\\"; on_run;\"", escapedPath);
+        command = buildCommand("sh -l -c \"source \\\"%s\\\"; on_run;\"", escapedPath);
     }
     if (header.useFBInk) {
         char* old_command = strdup(command);

--- a/tests/launcher_test_generate_command.c
+++ b/tests/launcher_test_generate_command.c
@@ -9,24 +9,24 @@ int main()
     char* command = getScriptCommand("./tests/test.sh");
     assert(command != NULL);
     printf("test.sh - %s\n", command);
-    assert(strcmp(command, "sh \"./tests/test.sh\"") == 0);
-    
+    assert(strcmp(command, "sh -l \"./tests/test.sh\"") == 0);
+
     free(command);
     command = getScriptCommand("./tests/test_fbink.sh");
     assert(command != NULL);
     printf("test_fbink.sh - %s\n", command);
-    assert(strcmp(command, "/mnt/us/libkh/bin/fbink -k; sh \"./tests/test_fbink.sh\" 2>&1 | /mnt/us/libkh/bin/fbink -y 5 -r") == 0);
+    assert(strcmp(command, "/mnt/us/libkh/bin/fbink -k; sh -l \"./tests/test_fbink.sh\" 2>&1 | /mnt/us/libkh/bin/fbink -y 5 -r") == 0);
 
     free(command);
     command = getScriptCommand("./tests/test_hooks_fbink.sh");
     assert(command != NULL);
     printf("test_fbink.sh - %s\n", command);
-    assert(strcmp(command, "/mnt/us/libkh/bin/fbink -k; sh -c \"source \\\"./tests/test_hooks_fbink.sh\\\"; on_run;\" 2>&1 | /mnt/us/libkh/bin/fbink -y 5 -r") == 0);
+    assert(strcmp(command, "/mnt/us/libkh/bin/fbink -k; sh -l -c \"source \\\"./tests/test_hooks_fbink.sh\\\"; on_run;\" 2>&1 | /mnt/us/libkh/bin/fbink -y 5 -r") == 0);
 
     free(command);
     command = getScriptCommand("./tests/test_hooks.sh");
     assert(command != NULL);
     printf("test_hooks.sh - %s\n", command);
-    assert(strcmp(command, "sh -c \"source \\\"./tests/test_hooks.sh\\\"; on_run;\"") == 0);
+    assert(strcmp(command, "sh -l -c \"source \\\"./tests/test_hooks.sh\\\"; on_run;\"") == 0);
     return 0;
 }

--- a/tests/launcher_test_generate_command.c
+++ b/tests/launcher_test_generate_command.c
@@ -28,5 +28,6 @@ int main()
     assert(command != NULL);
     printf("test_hooks.sh - %s\n", command);
     assert(strcmp(command, "sh -l -c \"source \\\"./tests/test_hooks.sh\\\"; on_run;\"") == 0);
+    free(command);
     return 0;
 }


### PR DESCRIPTION
Scripts currently run without `PATH` set at all.
This works somewhat okay for things directly launched within these scripts, because busybox defaults to `PATH=/sbin:/usr/sbin:/bin:/usr/bin` ([source](https://github.com/mirror/busybox/blob/371fe9f71d445d18be28c82a2a6d82115c8af19d/include/libbb.h#L2303)) for anything run in the script -- it's not set as an environment variable though, so it doesn't propagate to subprocesses.

This means directly running sh, eips, etc. will work fine, but any processes started (e.g. a daemon like utild) will have an unexpectedly empty PATH.

This changes `sh` to be invoked with `-l` (`--login`), which will execute `/etc/profile` and set the usual PATH.